### PR TITLE
Add rows on paste

### DIFF
--- a/plugins/slick.cellexternalcopymanager.js
+++ b/plugins/slick.cellexternalcopymanager.js
@@ -148,7 +148,16 @@
         destH = selectedRange.toRow - selectedRange.fromRow +1;
         destW = selectedRange.toCell - selectedRange.fromCell +1;
       }
-      
+		
+      var availableRows = _grid.getData().length - activeRow;
+      if(availableRows < destH)
+      {	
+        var d = _grid.getData();
+        for(var addRows = 1; addRows <= destH - availableRows; addRows++)
+          d.push({});
+        _grid.setData(d);
+        _grid.render();
+      }
       var desty = activeRow;
       var destx = activeCell;
       var maxDestY = _grid.getDataLength();


### PR DESCRIPTION
If the paste contains more rows than are available from the selected
start to the end of the grid, add enough blank rows to allow space for
the paste.
