### PR TITLE
Add blank rows at end before paste. Was dropped from undo/redo commit. 

### DIFF
--- a/plugins/slick.cellexternalcopymanager.js
+++ b/plugins/slick.cellexternalcopymanager.js
@@ -150,10 +150,11 @@
         destW = selectedRange.toCell - selectedRange.fromCell +1;
       }
 	  var availableRows = _grid.getData().length - activeRow;
+	  var addRows = 0;
 	  if(availableRows < destH)
 	  {
 		var d = _grid.getData();
-		for(var addRows = 1; addRows <= destH - availableRows; addRows++)
+		for(addRows = 1; addRows <= destH - availableRows; addRows++)
 			d.push({});
 		_grid.setData(d);
 		_grid.render();
@@ -243,6 +244,14 @@
           this.markCopySelection([bRange]);
           _grid.getSelectionModel().setSelectedRanges([bRange]);
           this.cellExternalCopyManager.onPasteCells.notify({ranges: [bRange]});
+          
+          if(addRows > 1){            
+            var d = _grid.getData();
+            for(; addRows > 1; addRows--)
+              d.splice(d.length - 1, 1);
+            _grid.setData(d);
+            _grid.render();
+          }
         }
       };
 

--- a/plugins/slick.cellexternalcopymanager.js
+++ b/plugins/slick.cellexternalcopymanager.js
@@ -149,7 +149,15 @@
         destH = selectedRange.toRow - selectedRange.fromRow +1;
         destW = selectedRange.toCell - selectedRange.fromCell +1;
       }
-
+	  var availableRows = _grid.getData().length - activeRow;
+	  if(availableRows < destH)
+	  {
+		var d = _grid.getData();
+		for(var addRows = 1; addRows <= destH - availableRows; addRows++)
+			d.push({});
+		_grid.setData(d);
+		_grid.render();
+	  }  
       var clipCommand = {
 
         isClipboardCommand: true,


### PR DESCRIPTION
That last commit dropped my change to add rows at the end of the grid before the paste. The undo/redo seems to still work with adding rows at end, though it doesn't actually remove the newly created rows, so maybe you dropped it intentionally. Here it is again, if you want it. 

Edit:after I commented that it didn't deleted newly added rows, I decided it would be useful to do just that. See second commit. 
