### PR TITLE
After a cell is copied, restore focus back to the original

### DIFF
--- a/plugins/slick.cellexternalcopymanager.js
+++ b/plugins/slick.cellexternalcopymanager.js
@@ -301,12 +301,16 @@
                 clipTextArr.push(clipTextRows.join("\r\n"));
             }
             var clipText = clipTextArr.join('');
+            var $focus = $(":focus");
+
             var ta = _createTextBox(clipText);
 
             ta.focus();
             
             setTimeout(function(){
                 document.body.removeChild(ta);
+                // restore focus
+                if ($focus && $focus.length>0) { $focus.focus(); }
             }, 100);
 
             return false;


### PR DESCRIPTION
After a cell is copied, I noticed that keyboard cell navigation would be broken.  This fixes it by restoring focus back to the original element before the copy.
