### PR TITLE
Using an actual dummy container

### DIFF
--- a/plugins/slick.cellexternalcopymanager.js
+++ b/plugins/slick.cellexternalcopymanager.js
@@ -88,7 +88,7 @@
       // if a custom getter is not defined, we call serializeValue of the editor to serialize
       if (columnDef.editor){
         var editorArgs = {
-          'container':$("body"),  // a dummy container
+          'container':$("<p>"),  // a dummy container
           'column':columnDef,
           'position':{'top':0, 'left':0}  // a dummy position required by some editors
         };


### PR DESCRIPTION
Choosing the document body as a dummy container caused massive conflicts for me -- it ended up applying some of my editors to every input in the entire body, which I didn't want to have happen.

This is a very small change that sets the dummy container to a detached `<p></p>` element, which works correctly and does not cause conflicts with things that are already in the DOM.
