### PR TITLE
Fixed includeHeaders to work for multiple rows

### DIFF
--- a/plugins/slick.cellexternalcopymanager.js
+++ b/plugins/slick.cellexternalcopymanager.js
@@ -321,7 +321,7 @@
                     var clipTextCells = [];
                     var dt = _grid.getDataItem(i);
                     
-                    if (clipText == "" && _options.includeHeaderWhenCopying) {
+                    if (clipTextRows == "" && _options.includeHeaderWhenCopying) {
                         var clipTextHeaders = [];
                         for (var j = range.fromCell; j < range.toCell + 1 ; j++) {
                             if (columns[j].name.length > 0)


### PR DESCRIPTION
Updated to use clipTextRows instead of clipText when determining whether
to include headers in copy text.  Previously would include header row
for each row selected.

![image](https://cloud.githubusercontent.com/assets/8116874/3529669/1759358a-079c-11e4-9edc-dd350e37a614.png)
